### PR TITLE
Заменено название класса header-wrapper

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,8 +1,21 @@
 html, body {
     margin: 0;
     padding: 0;
-    background-color: #263e5a;
+    background-color: #ffffff;
 }
+
+.visually-hidden {
+    position: absolute;
+    overflow: hidden;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    border: 0;
+    white-space: nowrap;
+    clip: rect(0 0 0 0);
+}
+
 .container {
     width: 694px;
     margin: 0 auto;
@@ -10,10 +23,9 @@ html, body {
     padding-left: 8px;
 }
 .header {
-    
-    background: transparent;
+    background-color: #263e5a;
 }
-.header-wrapper {
+.header__top {
     display: flex;
     justify-content: space-between;
     align-items: center;


### PR DESCRIPTION
Заменила header-wrapper на header__top, потому что внесла блок promo внутрь header и потребовались дополнительные оболочки header__top и header__bottom, поэтому классы с header__wrapper перенесены на header__top