### PR TITLE
Изменены паддинги для header__top

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,8 +1,21 @@
 html, body {
     margin: 0;
     padding: 0;
-    background-color: #263e5a;
+    background-color: #ffffff;
 }
+
+.visually-hidden {
+    position: absolute;
+    overflow: hidden;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    border: 0;
+    white-space: nowrap;
+    clip: rect(0 0 0 0);
+}
+
 .container {
     width: 694px;
     margin: 0 auto;
@@ -10,14 +23,15 @@ html, body {
     padding-left: 8px;
 }
 .header {
-    
-    background: transparent;
+    background-color: #263e5a;
 }
-.header-wrapper {
+
+.header__top {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 40px;
+    padding-top: 40px;
+    padding-bottom: 115px;
 }
 .logo {
     font-size: 30px;


### PR DESCRIPTION
Зачем было задавать padding всем сторонам сразу? padding-top действительно равен 40px, padding-bottom уже равен 115px, от нижней границы текста в header__top до верхней границы текста в header__bottom. Горизонтальные паддинги в этом случае вообще не нужны, так как они уже заданы через container